### PR TITLE
Picasso Downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Memory Policy:
 ```java
 CatKit.with(context).dp(200, 200).memoryPolicy(MemoryPolicy.NO_CACHE).into(targetImageView);
 ```
+## Usage with Picasso Downloader
+
+If you already use Picasso for image loading you can override the downloader to provide cat images throughout your existing app
+```java
+Picasso picasso = new Picasso.Builder(this).downloader(new CatKitDownloader(this)).build();
+picasso.load("http://dummyurl.com") //this url will be ignored by CatKitDownloader
+        .into(targetImageView);
+```
 
 ## Install
 

--- a/catkit/build.gradle
+++ b/catkit/build.gradle
@@ -29,7 +29,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }
 

--- a/catkit/src/main/java/github/cesarferreira/catkit/CatKit.java
+++ b/catkit/src/main/java/github/cesarferreira/catkit/CatKit.java
@@ -64,7 +64,7 @@ public class CatKit {
     }
 
     private String getUrl() {
-        return "http://lorempixel.com/" + mWidth + "/" + mHeight + "/cats";
+        return Util.getUrl(mHeight, mWidth);
     }
 
 

--- a/catkit/src/main/java/github/cesarferreira/catkit/CatKitDownloader.java
+++ b/catkit/src/main/java/github/cesarferreira/catkit/CatKitDownloader.java
@@ -1,0 +1,24 @@
+package github.cesarferreira.catkit;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.squareup.picasso.UrlConnectionDownloader;
+
+import java.io.IOException;
+
+/**
+ * Custom {@link com.squareup.picasso.Downloader} to be used with {@link com.squareup.picasso.Picasso.Builder#downloader}
+ */
+public class CatKitDownloader extends UrlConnectionDownloader{
+
+    public CatKitDownloader(Context context){
+        super(context);
+    }
+
+    @Override
+    public Response load(Uri uri, int networkPolicy) throws IOException {
+        uri = Uri.parse(Util.getUrl(200,200));
+        return super.load(uri, networkPolicy);
+    }
+}

--- a/catkit/src/main/java/github/cesarferreira/catkit/Util.java
+++ b/catkit/src/main/java/github/cesarferreira/catkit/Util.java
@@ -1,0 +1,9 @@
+package github.cesarferreira.catkit;
+
+public class Util {
+
+    public static String getUrl(int height, int width) {
+        return "http://lorempixel.com/" + width + "/" + height + "/cats";
+    }
+
+}

--- a/example/src/main/java/github/cesarferreira/catkit/example/MainActivity.java
+++ b/example/src/main/java/github/cesarferreira/catkit/example/MainActivity.java
@@ -6,8 +6,10 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.ImageView;
 
 import com.squareup.picasso.MemoryPolicy;
+import com.squareup.picasso.Picasso;
 
 import github.cesarferreira.catkit.CatKit;
+import github.cesarferreira.catkit.CatKitDownloader;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -24,9 +26,14 @@ public class MainActivity extends AppCompatActivity {
         // CatKit.with(context).dp(200, 200).into(targetImageView);
 
         // More complete way
-        CatKit.with(context)
-                .dp(300, 400)
-                .memoryPolicy(MemoryPolicy.NO_STORE)
+        //CatKit.with(context)
+        //        .dp(300, 400)
+        //        .memoryPolicy(MemoryPolicy.NO_STORE)
+        //        .into(targetImageView);
+
+        // Using Picasso downloader
+        Picasso picasso = new Picasso.Builder(this).downloader(new CatKitDownloader(this)).build();
+        picasso.load("http://dummyurl.com") //this url doesn't matter since it will be ignored by CatKitDownloader
                 .into(targetImageView);
     }
 


### PR DESCRIPTION
Demonstration of overriding the default Picasso downloader. If you are using Picasso already in an app, then this allows you to drop CatKitDownloader into your existing image loading code and replace all images with cats!
